### PR TITLE
Chore/add show on stores page

### DIFF
--- a/db/store.ts
+++ b/db/store.ts
@@ -105,7 +105,14 @@ export async function getStoresForStoresPage(db: Db) {
         },
       },
     ])
-    .project({ _id: 1, name: 1, openDate: 1, closeDate: 1, permanentlyOpen: 1 })
+    .project({
+      _id: 1,
+      name: 1,
+      openDate: 1,
+      closeDate: 1,
+      permanentlyOpen: 1,
+      showOnStoresPage: 1,
+    })
     .toArray();
   return await result;
 }

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -199,6 +199,7 @@ export interface Store {
     text: string;
     createdAt: string;
   };
+  showOnStoresPage: boolean;
   createdAt: string;
   updatedAt: string;
 }

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -211,6 +211,7 @@ export interface StoreForStoresPage {
   closeDate: string;
   permanentlyOpen: boolean;
   featuredImg: string;
+  showOnStoresPage: boolean;
 }
 
 export interface CheckoutForm {

--- a/pages/stores.tsx
+++ b/pages/stores.tsx
@@ -12,7 +12,7 @@ export const getServerSideProps: GetServerSideProps = async () => {
   const stores = await store.getStoresForStoresPage(db);
   const activeStores = stores?.filter(s => {
     const isActive = getStoreStatus(s.openDate, s.closeDate);
-    return isActive;
+    return isActive && s.showOnStoresPage;
   });
 
   const res = activeStores || null;


### PR DESCRIPTION
- add `showOnStoresPage` to `Store` and `StoreForStoresPage` interfaces.
- add `showOnStoresPage` to `getStoresForStoresPage` projection.
- update `getServerSideProps` on `/stores` page to also check for `showOnStoresPage`.