### PR TITLE
SendToProd/sheboygan lutheran discount eligibility bug fixes

### DIFF
--- a/components/store/checkout/CheckoutForm.tsx
+++ b/components/store/checkout/CheckoutForm.tsx
@@ -21,6 +21,9 @@ import { CartItem, ShippingData, UseCheckoutSubmit } from 'interfaces';
 type Props = {
   storeId: string;
   storeName: string;
+  cartSubtotal: number;
+  cartTotal: number;
+  cartShipping: number;
   allowDirectShipping: boolean;
   allowStorePickup: boolean;
   hasPrimaryShipping: boolean;
@@ -80,7 +83,8 @@ export default function CheckoutForm(props: Props) {
       ...(lastNameForSheboyganLutheranStaff && {
         lastName: lastNameForSheboyganLutheranStaff,
       }),
-      ...(emailForSheboyganLutheranStaff &&
+      ...(props.applySheboyganLutheranStaffDiscount &&
+        emailForSheboyganLutheranStaff &&
         isEligibleForSheboyganLutheranStaff &&
         !alreadyUsedForSheboyganLutheranStaff && {
           email: emailForSheboyganLutheranStaff,
@@ -97,12 +101,12 @@ export default function CheckoutForm(props: Props) {
   function getOrderTotal() {
     if (
       props.onlyDirectShipping &&
-      cart.cartSubtotal < props.shippingFreeMinimum &&
+      props.cartSubtotal < props.shippingFreeMinimum &&
       !props.applySheboyganLutheranStaffDiscount
     ) {
-      return cart.cartTotal + props.shippingPrice;
+      return props.cartTotal + props.shippingPrice;
     }
-    return cart.cartTotal;
+    return props.cartTotal;
   }
 
   // only run on first render
@@ -264,7 +268,7 @@ export default function CheckoutForm(props: Props) {
                                 ? ` (free with orders over ${formatToMoney(
                                     props.shipping.freeMinimum,
                                     true
-                                  )}`
+                                  )})`
                                 : ''}
                             </div>
                             <div className="shipping-price">

--- a/components/store/checkout/CheckoutForm.tsx
+++ b/components/store/checkout/CheckoutForm.tsx
@@ -23,7 +23,6 @@ type Props = {
   storeName: string;
   cartSubtotal: number;
   cartTotal: number;
-  cartShipping: number;
   allowDirectShipping: boolean;
   allowStorePickup: boolean;
   hasPrimaryShipping: boolean;
@@ -54,7 +53,6 @@ export default function CheckoutForm(props: Props) {
   const router = useRouter();
   const hasMounted = useHasMounted();
 
-  // TODO: should I clean this up and bring in as a prop from the parent component?
   const {
     alreadyUsed: alreadyUsedForSheboyganLutheranStaff,
     isEligible: isEligibleForSheboyganLutheranStaff,
@@ -62,12 +60,7 @@ export default function CheckoutForm(props: Props) {
     lastName: lastNameForSheboyganLutheranStaff,
     email: emailForSheboyganLutheranStaff,
   } = useSheboyganLutheranStaff();
-  // TODO: should I clean this up and bring in as a prop from the parent component?
-  const cart = useCart({
-    sheboyganLutheranStaffEligible:
-      isEligibleForSheboyganLutheranStaff &&
-      !alreadyUsedForSheboyganLutheranStaff,
-  });
+  const cart = useCart();
 
   const [initialValues] = React.useState(() =>
     getInitialValues({
@@ -76,7 +69,7 @@ export default function CheckoutForm(props: Props) {
         props.hasPrimaryShipping || !!props.applySheboyganLutheranStaffDiscount,
       allowDirectShipping: props.allowDirectShipping,
       allowStorePickup: props.allowStorePickup,
-      cartTotal: cart.cartTotal,
+      cartTotal: props.cartTotal,
       ...(firstNameForSheboyganLutheranStaff && {
         firstName: firstNameForSheboyganLutheranStaff,
       }),
@@ -93,7 +86,7 @@ export default function CheckoutForm(props: Props) {
   );
 
   const cartOnlyHasFreeItems =
-    !props.checkout.cartIsEmpty && cart.cartTotal === 0;
+    !props.checkout.cartIsEmpty && props.cartTotal === 0;
 
   // TODO: move this to the useCart logic (if possible)
   // NOTE: this function is also used in CheckoutForm.tsx and should be kept in sync
@@ -264,7 +257,7 @@ export default function CheckoutForm(props: Props) {
                             />
                             <div className="shipping-label">
                               Ship directly to you
-                              {cart.cartSubtotal >= props.shipping.freeMinimum
+                              {props.cartSubtotal >= props.shipping.freeMinimum
                                 ? ` (free with orders over ${formatToMoney(
                                     props.shipping.freeMinimum,
                                     true
@@ -272,7 +265,7 @@ export default function CheckoutForm(props: Props) {
                                 : ''}
                             </div>
                             <div className="shipping-price">
-                              {cart.cartSubtotal >= props.shipping.freeMinimum
+                              {props.cartSubtotal >= props.shipping.freeMinimum
                                 ? 'Free'
                                 : formatToMoney(props.shipping.price, true)}
                             </div>

--- a/hooks/useCheckoutSubmit.tsx
+++ b/hooks/useCheckoutSubmit.tsx
@@ -19,7 +19,7 @@ type Props = {
     state: string;
     zipcode: string;
   };
-  cartTotal: number;
+  sheboyganLutheranStaffId?: string;
   isSwitchFitnessStore: boolean;
   isEligibleForSheboyganLutheranStaffFromClient: boolean;
 };
@@ -49,6 +49,7 @@ export default function useCheckoutSubmit(props: Props): UseCheckoutSubmit {
   const { items, cartSubtotal, salesTax, cartTotal, cartIsEmpty, setItems } =
     useCart({
       sheboyganLutheranStaffEligible:
+        !!props.sheboyganLutheranStaffId &&
         isEligibleForSheboyganLutheranStaff &&
         !alreadyUsedForSheboyganLutheranStaff,
     });

--- a/pages/api/submit-order.ts
+++ b/pages/api/submit-order.ts
@@ -110,16 +110,8 @@ export default async (req: ExtendedRequest, res: NextApiResponse) => {
       ) &&
       !sheboyganLutheranStaff.usedEmails.includes(sheboyganLutheranStaffEmail);
 
-    console.log({
-      isEligibleForSheboyganLutheranStaffFromClient:
-        req.body.isEligibleForSheboyganLutheranStaffFromClient,
-      shebLuthStaffId: sheboyganLutheranStaffId,
-      shebLuthStaffEmail: sheboyganLutheranStaffEmail,
-      isEligibleForSheboyganLutheranStaffDiscount:
-        isEligibleForSheboyganLutheranStaffDiscount,
-    });
-
     if (
+      !!sheboyganLutheranStaffId &&
       req.body.isEligibleForSheboyganLutheranStaffFromClient &&
       !isEligibleForSheboyganLutheranStaffDiscount
     ) {

--- a/pages/store/[id]/cart.tsx
+++ b/pages/store/[id]/cart.tsx
@@ -75,6 +75,7 @@ export default function Cart(props: Props) {
     name: storeName,
     products,
     teacherAppreciationId,
+    sheboyganLutheranStaffId,
   } = store;
 
   const {
@@ -102,6 +103,7 @@ export default function Cart(props: Props) {
 
   const cart = useCart({
     sheboyganLutheranStaffEligible:
+      !!sheboyganLutheranStaffId &&
       isEligibleForSheboyganLutheranStaff &&
       !alreadyUsedForSheboyganLutheranStaff,
   });

--- a/pages/store/[id]/checkout.tsx
+++ b/pages/store/[id]/checkout.tsx
@@ -98,11 +98,12 @@ export default function Checkout(props: Props) {
     storeId: props.store._id,
     storeName: props.store.name,
     primaryShippingAddress: props.store.primaryShippingLocation,
-    cartTotal: cart.cartTotal,
+    sheboyganLutheranStaffId: props.store.sheboyganLutheranStaffId,
     isSwitchFitnessStore:
       !!props.store.meta?.isSwitchFitness &&
       !!props.store.meta?.switchFitnessDiscountId,
     isEligibleForSheboyganLutheranStaffFromClient:
+      !!props.store.sheboyganLutheranStaffId &&
       isEligibleForSheboyganLutheranStaff &&
       !alreadyUsedForSheboyganLutheranStaff,
   });
@@ -161,7 +162,6 @@ export default function Checkout(props: Props) {
             setShowInventoryModal={checkout.setShowInventoryModal}
             checkout={checkout}
             cartSubtotal={cart.cartSubtotal}
-            cartShipping={cart.shipping}
             cartTotal={cart.cartTotal}
             {...{ applySheboyganLutheranStaffDiscount }}
             onlyDirectShipping={props.onlyDirectShipping}

--- a/pages/store/[id]/checkout.tsx
+++ b/pages/store/[id]/checkout.tsx
@@ -138,10 +138,6 @@ export default function Checkout(props: Props) {
     isSheboyganLutheranStaffStore &&
     isEligibleForSheboyganLutheranStaff &&
     !alreadyUsedForSheboyganLutheranStaff;
-  console.log({
-    isSheboyganLutheranStaffStore,
-    applySheboyganLutheranStaffDiscount,
-  });
 
   return (
     <StoreLayout title={`Checkout | ${props.store.name}`}>

--- a/pages/store/[id]/checkout.tsx
+++ b/pages/store/[id]/checkout.tsx
@@ -89,6 +89,7 @@ export default function Checkout(props: Props) {
 
   const cart = useCart({
     sheboyganLutheranStaffEligible:
+      !!props.store.sheboyganLutheranStaffId &&
       isEligibleForSheboyganLutheranStaff &&
       !alreadyUsedForSheboyganLutheranStaff,
   });
@@ -137,6 +138,10 @@ export default function Checkout(props: Props) {
     isSheboyganLutheranStaffStore &&
     isEligibleForSheboyganLutheranStaff &&
     !alreadyUsedForSheboyganLutheranStaff;
+  console.log({
+    isSheboyganLutheranStaffStore,
+    applySheboyganLutheranStaffDiscount,
+  });
 
   return (
     <StoreLayout title={`Checkout | ${props.store.name}`}>
@@ -159,9 +164,10 @@ export default function Checkout(props: Props) {
             setOutOfStockItems={checkout.setOutOfStockItems}
             setShowInventoryModal={checkout.setShowInventoryModal}
             checkout={checkout}
-            applySheboyganLutheranStaffDiscount={
-              applySheboyganLutheranStaffDiscount
-            }
+            cartSubtotal={cart.cartSubtotal}
+            cartShipping={cart.shipping}
+            cartTotal={cart.cartTotal}
+            {...{ applySheboyganLutheranStaffDiscount }}
             onlyDirectShipping={props.onlyDirectShipping}
             shippingPrice={props.shipping.price}
             shippingFreeMinimum={props.shipping.freeMinimum}

--- a/pages/store/[id]/demo/checkout.tsx
+++ b/pages/store/[id]/demo/checkout.tsx
@@ -147,6 +147,9 @@ export default function Checkout(props: Props) {
               setOutOfStockItems={checkout.setOutOfStockItems}
               setShowInventoryModal={checkout.setShowInventoryModal}
               checkout={checkout}
+              cartSubtotal={cart.cartSubtotal}
+              cartShipping={cart.shipping}
+              cartTotal={cart.cartTotal}
               applySheboyganLutheranStaffDiscount={
                 applySheboyganLutheranStaffDiscount
               }

--- a/pages/store/[id]/demo/checkout.tsx
+++ b/pages/store/[id]/demo/checkout.tsx
@@ -83,11 +83,12 @@ export default function Checkout(props: Props) {
     storeId: props.store._id,
     storeName: props.store.name,
     primaryShippingAddress: props.store.primaryShippingLocation,
-    cartTotal: cart.cartTotal,
+    sheboyganLutheranStaffId: props.store.sheboyganLutheranStaffId,
     isSwitchFitnessStore:
       !!props.store.meta?.isSwitchFitness &&
       !!props.store.meta?.switchFitnessDiscountId,
     isEligibleForSheboyganLutheranStaffFromClient:
+      !!props.store.sheboyganLutheranStaffId &&
       isEligibleForSheboyganLutheranStaff &&
       !alreadyUsedForSheboyganLutheranStaff,
   });
@@ -148,7 +149,6 @@ export default function Checkout(props: Props) {
               setShowInventoryModal={checkout.setShowInventoryModal}
               checkout={checkout}
               cartSubtotal={cart.cartSubtotal}
-              cartShipping={cart.shipping}
               cartTotal={cart.cartTotal}
               applySheboyganLutheranStaffDiscount={
                 applySheboyganLutheranStaffDiscount


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                 
  - Fixes a bug where Sheboygan Lutheran Staff discount eligibility (stored in
    localStorage as `sheb-luth-staff-25`) persisted across stores. Once a user                                                                                                                                   
    verified their email at the Sheboygan store, the eligibility flag leaked into
    every other store they visited, with three observable symptoms:                                                                                                                                              
    1. Cart and checkout pages could display the $75 discount on stores that                                                                                                                                     
       don't have it configured                                                                                                                                                                                  
    2. Submitting an order on a non-Sheboygan store returned the server-side                                                                                                                                     
       "Your email is either ineligible or has already been used" error,                                                                                                                                         
       blocking checkout entirely                                                                                                                                                                                
    3. The local `useCart` in `useCheckoutSubmit` could compute a discounted                                                                                                                                     
       `cartTotal === 0`, skipping Stripe payment method creation, leading to                                                                                                                                    
       a charge failure when the server (correctly) calculated the real total                                                                                                                                    
  - Added `!!sheboyganLutheranStaffId` storefront guards everywhere eligibility                                                                                                                                  
    is read or sent to the server (cart page, checkout page, demo checkout,                                                                                                                                      
    `CheckoutForm`, `useCheckoutSubmit`)                                                                                                                                                                         
  - Added the same guard server-side in `submit-order.ts` so a stale or                                                                                                                                          
    mismatched client claim can't trip the rejection path                                                                                                                                                        
  - Routed `CheckoutForm` totals through props instead of a redundant local                                                                                                                                      
    `useCart` call so the discount-aware totals flow from a single guarded                                                                                                                                       
    source                                                                                                                                                                                                       
  - Removed two debug `console.log` blocks and a dead `cartShipping` /                                                                                                                                           
    `cartTotal` prop while in the area                                                                                                                                                                           
                                                                                                                                                                                                                 
  ## Test plan    
                                                                                                                                                                                                                 
  - [ ] Clean localStorage, shop a non-Sheboygan store → no discount, normal totals
  - [ ] Verify a Sheboygan email, shop the Sheboygan store → discount applies, totals correct                                                                                                                    
  - [ ] Verify a Sheboygan email, then shop a non-Sheboygan store → no discount, order submits successfully
  - [ ] Verify a Sheboygan email at a Sheboygan store and complete an order end-to-end (Stripe charge succeeds, receipt email sends) 