### PR TITLE
SendToProd/Handle paused state and normalize emails for Teacher Appreciation

### DIFF
--- a/components/store/home/TeacherAppreciation.tsx
+++ b/components/store/home/TeacherAppreciation.tsx
@@ -16,10 +16,12 @@ export default function TeacherAppreciation({
   teacherAppreciationId,
   productLink,
 }: Props) {
-  const { alreadyUsed, email, isEligible, resetState, verifyEmail } =
+  const { alreadyUsed, email, isEligible, paused, resetState, verifyEmail } =
     useTeacherAppreciation();
 
-  const notEligibleNotAlreadyUsed = email && !isEligible && !alreadyUsed;
+  const programPaused = email && paused;
+  const notEligibleNotAlreadyUsed =
+    email && !isEligible && !alreadyUsed && !paused;
   const notEligibleAlreadyUsed = email && !isEligible && alreadyUsed;
 
   return (
@@ -106,6 +108,13 @@ export default function TeacherAppreciation({
                   {notEligibleAlreadyUsed ? (
                     <div className="validation-error">
                       This email already used the discount.
+                    </div>
+                  ) : null}
+                  {/* Message for program paused */}
+                  {programPaused ? (
+                    <div className="validation-error">
+                      The teacher appreciation discount is currently paused.
+                      Please try again later.
                     </div>
                   ) : null}
                 </Form>

--- a/db/teacherAppreciation.ts
+++ b/db/teacherAppreciation.ts
@@ -25,15 +25,19 @@ export async function verifyTeacherAppreciationEmailEligibility(
     throw new Error('Teacher appreciation not found');
   }
 
-  const lowercaseEmail = email.toLowerCase();
+  const normalizedEmail = email.trim().toLowerCase();
+  const eligibleEmails = teacherAppreciation.eligibleEmails.map(e =>
+    e.trim().toLowerCase()
+  );
+  const usedEmails = teacherAppreciation.usedEmails.map(e =>
+    e.trim().toLowerCase()
+  );
 
   const paused = !teacherAppreciation.active;
-  const alreadyUsed = teacherAppreciation.usedEmails.includes(lowercaseEmail);
+  const alreadyUsed = usedEmails.includes(normalizedEmail);
   const isEligible =
-    !paused &&
-    teacherAppreciation.eligibleEmails.includes(lowercaseEmail) &&
-    !alreadyUsed;
-  return { isEligible, alreadyUsed, paused };
+    !paused && eligibleEmails.includes(normalizedEmail) && !alreadyUsed;
+  return { isEligible, alreadyUsed, paused, email: normalizedEmail };
 }
 
 // ****************************************************
@@ -51,17 +55,20 @@ export async function addUsedEmailToTeacherAppreciation(
     throw new Error('Teacher appreciation not found');
   }
 
-  if (teacherAppreciation.usedEmails.includes(email)) {
+  const normalizedEmail = email.trim().toLowerCase();
+  const usedEmails = teacherAppreciation.usedEmails.map(e =>
+    e.trim().toLowerCase()
+  );
+
+  if (usedEmails.includes(normalizedEmail)) {
     throw new Error('Email has already been used');
   }
-
-  const lowercaseEmail = email.toLowerCase();
 
   const updateResult = await db
     .collection<OptionalId<TeacherAppreciation>>('teacherAppreciation')
     .updateOne(
       { _id: new ObjectID(_id) },
-      { $push: { usedEmails: lowercaseEmail } }
+      { $push: { usedEmails: normalizedEmail } }
     );
   if (updateResult.result.ok === 0) {
     throw new Error('Failed to add teacher appreciation email to usedEmails');
@@ -70,7 +77,7 @@ export async function addUsedEmailToTeacherAppreciation(
   const updatedTeacherAppreciation: TeacherAppreciation = {
     ...teacherAppreciation,
     _id,
-    usedEmails: [...teacherAppreciation.usedEmails, email],
+    usedEmails: [...teacherAppreciation.usedEmails, normalizedEmail],
   };
   return updatedTeacherAppreciation;
 }

--- a/db/teacherAppreciation.ts
+++ b/db/teacherAppreciation.ts
@@ -27,11 +27,13 @@ export async function verifyTeacherAppreciationEmailEligibility(
 
   const lowercaseEmail = email.toLowerCase();
 
+  const paused = !teacherAppreciation.active;
+  const alreadyUsed = teacherAppreciation.usedEmails.includes(lowercaseEmail);
   const isEligible =
-    teacherAppreciation?.eligibleEmails.includes(lowercaseEmail) &&
-    !teacherAppreciation?.usedEmails.includes(lowercaseEmail);
-  const alreadyUsed = teacherAppreciation?.usedEmails.includes(lowercaseEmail);
-  return { isEligible, alreadyUsed };
+    !paused &&
+    teacherAppreciation.eligibleEmails.includes(lowercaseEmail) &&
+    !alreadyUsed;
+  return { isEligible, alreadyUsed, paused };
 }
 
 // ****************************************************

--- a/hooks/useTeacherAppreciation.tsx
+++ b/hooks/useTeacherAppreciation.tsx
@@ -5,12 +5,14 @@ type TeacherAppreciationState = {
   email: string | undefined;
   isEligible: boolean;
   alreadyUsed: boolean;
+  paused: boolean;
 };
 
 const initialState: TeacherAppreciationState = {
   email: undefined,
   isEligible: false,
   alreadyUsed: false,
+  paused: false,
 };
 
 type TeacherAppreciationContextType = TeacherAppreciationState & {
@@ -23,6 +25,7 @@ type TeacherAppreciationContextType = TeacherAppreciationState & {
   }) => Promise<{
     isEligible: boolean;
     alreadyUsed: boolean;
+    paused: boolean;
   }>;
   resetState: () => void;
 };
@@ -84,9 +87,11 @@ function TeacherAppreciationProvider({
     const {
       isEligible,
       alreadyUsed,
-    }: { isEligible: boolean; alreadyUsed: boolean } = await response.json();
-    saveState({ email, isEligible, alreadyUsed });
-    return { isEligible, alreadyUsed };
+      paused,
+    }: { isEligible: boolean; alreadyUsed: boolean; paused: boolean } =
+      await response.json();
+    saveState({ email, isEligible, alreadyUsed, paused });
+    return { isEligible, alreadyUsed, paused };
   };
 
   const resetState = () => {

--- a/hooks/useTeacherAppreciation.tsx
+++ b/hooks/useTeacherAppreciation.tsx
@@ -26,6 +26,7 @@ type TeacherAppreciationContextType = TeacherAppreciationState & {
     isEligible: boolean;
     alreadyUsed: boolean;
     paused: boolean;
+    email: string;
   }>;
   resetState: () => void;
 };
@@ -88,10 +89,20 @@ function TeacherAppreciationProvider({
       isEligible,
       alreadyUsed,
       paused,
-    }: { isEligible: boolean; alreadyUsed: boolean; paused: boolean } =
-      await response.json();
-    saveState({ email, isEligible, alreadyUsed, paused });
-    return { isEligible, alreadyUsed, paused };
+      email: normalizedEmail,
+    }: {
+      isEligible: boolean;
+      alreadyUsed: boolean;
+      paused: boolean;
+      email: string;
+    } = await response.json();
+    saveState({
+      email: normalizedEmail,
+      isEligible,
+      alreadyUsed,
+      paused,
+    });
+    return { isEligible, alreadyUsed, paused, email: normalizedEmail };
   };
 
   const resetState = () => {

--- a/pages/api/submit-order.ts
+++ b/pages/api/submit-order.ts
@@ -123,7 +123,7 @@ export default async (req: ExtendedRequest, res: NextApiResponse) => {
 
     // teacher appreciation verification
     const teacherAppreciationEmail =
-      req.body.teacherAppreciationEmail?.toLowerCase() ?? '';
+      req.body.teacherAppreciationEmail?.trim().toLowerCase() ?? '';
     const teacherAppreciationId = store.teacherAppreciationId;
 
     let teacherAppreciation;
@@ -139,11 +139,17 @@ export default async (req: ExtendedRequest, res: NextApiResponse) => {
     const teacherAppreciationProgramPaused =
       !!teacherAppreciation && !teacherAppreciation.active;
 
+    const teacherAppreciationEligibleEmails =
+      teacherAppreciation?.eligibleEmails.map(e => e.trim().toLowerCase()) ??
+      [];
+    const teacherAppreciationUsedEmails =
+      teacherAppreciation?.usedEmails.map(e => e.trim().toLowerCase()) ?? [];
+
     const isEligibleForTeacherAppreciation =
       !!teacherAppreciation &&
       teacherAppreciation.active &&
-      teacherAppreciation.eligibleEmails.includes(teacherAppreciationEmail) &&
-      !teacherAppreciation.usedEmails.includes(teacherAppreciationEmail);
+      teacherAppreciationEligibleEmails.includes(teacherAppreciationEmail) &&
+      !teacherAppreciationUsedEmails.includes(teacherAppreciationEmail);
 
     // check if the cart has a teacher appreciation item
     const cartHasTeacherAppreciationItem = req.body.items.some(item => {

--- a/pages/api/submit-order.ts
+++ b/pages/api/submit-order.ts
@@ -136,6 +136,9 @@ export default async (req: ExtendedRequest, res: NextApiResponse) => {
         );
     }
 
+    const teacherAppreciationProgramPaused =
+      !!teacherAppreciation && !teacherAppreciation.active;
+
     const isEligibleForTeacherAppreciation =
       !!teacherAppreciation &&
       teacherAppreciation.active &&
@@ -156,9 +159,9 @@ export default async (req: ExtendedRequest, res: NextApiResponse) => {
       !isEligibleForTeacherAppreciation
     ) {
       return res.json({
-        // error: 'Teacher Appreciation email is invalid or has already been used',
-        error:
-          'Your email is either ineligible or has already been used for the teacher appreciation discount.',
+        error: teacherAppreciationProgramPaused
+          ? 'The teacher appreciation discount is currently paused. Please try again later.'
+          : 'Your email is either ineligible or has already been used for the teacher appreciation discount.',
       });
     }
 

--- a/pages/api/teacher-appreciation/verify-email.ts
+++ b/pages/api/teacher-appreciation/verify-email.ts
@@ -15,13 +15,13 @@ const handler = nc<ExtendedRequest, NextApiResponse>()
   .use(database)
   .post(async (req, res) => {
     const { id, email } = req.body;
-    const { isEligible, alreadyUsed } =
+    const { isEligible, alreadyUsed, paused } =
       await teacherAppreciation.verifyTeacherAppreciationEmailEligibility(
         req.db,
         id,
         email
       );
-    res.json({ isEligible, alreadyUsed });
+    res.json({ isEligible, alreadyUsed, paused });
   });
 
 export default handler;

--- a/pages/api/teacher-appreciation/verify-email.ts
+++ b/pages/api/teacher-appreciation/verify-email.ts
@@ -15,13 +15,17 @@ const handler = nc<ExtendedRequest, NextApiResponse>()
   .use(database)
   .post(async (req, res) => {
     const { id, email } = req.body;
-    const { isEligible, alreadyUsed, paused } =
-      await teacherAppreciation.verifyTeacherAppreciationEmailEligibility(
-        req.db,
-        id,
-        email
-      );
-    res.json({ isEligible, alreadyUsed, paused });
+    const {
+      isEligible,
+      alreadyUsed,
+      paused,
+      email: normalizedEmail,
+    } = await teacherAppreciation.verifyTeacherAppreciationEmailEligibility(
+      req.db,
+      id,
+      email
+    );
+    res.json({ isEligible, alreadyUsed, paused, email: normalizedEmail });
   });
 
 export default handler;


### PR DESCRIPTION
 ## Summary

  - Surfaces a clear "the teacher appreciation discount is currently paused"
    message in two places when an admin sets `active: false`:
    1. On the store homepage right when a user enters their email (so they
       don't get to "verified, here's your free shirt" UI on a paused program)
    2. Under the Submit button at checkout for users who already verified
       before the admin paused, so the rejection reason is accurate instead
       of the misleading "your email is either ineligible or has already been
       used" bundle
  - Normalizes Teacher Appreciation emails end-to-end so admin-side typos
    and user-side input quirks no longer cause silent eligibility failures:
    - Trims whitespace and lowercases on both the verify and submit paths
      (catches users who paste `" Jane@School.org "` from email signatures)
    - Normalizes the stored `eligibleEmails` and `usedEmails` arrays at read
      time so a `Jane@School.org` entry from admin tooling matches a
      `jane@school.org` user submission
    - Fixes a case-sensitivity bug in `addUsedEmailToTeacherAppreciation`
      where the dedup check ran against the original case but the push
      used lowercase, allowing the same email to be stored twice
    - Returns the normalized email from `/api/teacher-appreciation/verify-email`
      and saves that to localStorage so "Your email" in the UI displays the
      canonical lowercase form (matching what shows on the order receipt)

  ## Test plan

  - [ ] Set `active: false` on the TeacherAppreciation document, hit the
        store homepage, enter your eligible email → see "discount is currently
        paused" message instead of the eligibility success UI
  - [ ] Verify your email while `active: true`, then flip to `active: false`,
        submit the order → see the "currently paused" rejection under the
        Submit button instead of the "ineligible or already used" message
  - [ ] Set `active: true` and verify with `" SEANHASENSTEIN@gmail.com "`
        (extra whitespace, mixed case) → eligible, "Your email" displays as
        `seanhasenstein@gmail.com`
  - [ ] Set an `eligibleEmails` entry to mixed case in the DB (e.g.
        `Jane@School.org`), verify with `jane@school.org` → eligible
  - [ ] Regular eligible flow with `active: true` and matching-case emails →
        unchanged
